### PR TITLE
Rewrite originalUrl on request object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function rewrite(src, dst) {
         return next();
       }
     }
-    req.url = (dst || src).replace(/\$(\d+)|(?::(\w+))/g, function(_, n, name) {
+    req.url = req.originalUrl = (dst || src).replace(/\$(\d+)|(?::(\w+))/g, function(_, n, name) {
       if (name) {
         if (m) return m[map[name].index + 1];
         else return req.params[name];


### PR DESCRIPTION
Hi! 

This is a PR for rewriting the `originalUrl` on express request object too.

I'm working with Angular SSR and when I send the request to Angular it's use the `originalUrl` like you can see bellow:

https://github.com/angular/universal/blob/master/modules/ng-express-engine/src/main.ts#L72

What you think about?
Thanks!

