### PR TITLE
Implement basic Query String Append for query merging

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,11 +41,13 @@ function rewrite(src, dst, flags) {
   return function(req, res, next) {
     var orig = req.url;
     var origQuery;
+    var origOrig;
 
     if(qsa){
       var parsed=URL.parse(orig, true)
       origQuery=parsed.query
       debug('orig query params', origQuery)
+      origOrig=orig;
       orig=parsed.pathname
     }
 
@@ -70,6 +72,8 @@ function rewrite(src, dst, flags) {
     if(qsa){
       var urlObj=URL.parse(req.url, true);
       urlObj.query=Object.assign(origQuery, urlObj.query)
+      delete urlObj.search;
+      console.log("urlObj", urlObj.query)
       req.url=req.originalUrl=URL.format(urlObj)
 
     }
@@ -77,6 +81,8 @@ function rewrite(src, dst, flags) {
       req.query = URL.parse(req.url, true).query;
       debug('rewrite updated new query', req.query);
     }
+    console.log("received->", req.url)
+    console.log("origOrig->", origOrig)
     if (dst) next();
     else next('route');
   }

--- a/index.js
+++ b/index.js
@@ -73,7 +73,6 @@ function rewrite(src, dst, flags) {
       var urlObj=URL.parse(req.url, true);
       urlObj.query=Object.assign(origQuery, urlObj.query)
       delete urlObj.search;
-      console.log("urlObj", urlObj.query)
       req.url=req.originalUrl=URL.format(urlObj)
 
     }
@@ -81,8 +80,8 @@ function rewrite(src, dst, flags) {
       req.query = URL.parse(req.url, true).query;
       debug('rewrite updated new query', req.query);
     }
-    console.log("received->", req.url)
-    console.log("origOrig->", origOrig)
+    debug("received->", req.url)
+    debug("origOrig->", origOrig)
     if (dst) next();
     else next('route');
   }


### PR DESCRIPTION
Hi there, 

This PR resolves #2 implementing a basic Query String Append inspired in httpd's mod_rewrite. It is backwards compatible, since it only kicks-in if an optional flag array is passed that includes "QSA". 

Sample usage would be like:

```
app.use(rewrite("/mypath/:to_query/*", "/newpath/$2?param1=$1&param2=whatever", ["QSA"]))
```
I've used mod_rewrite's flag array concept, so that more flags could easily be added in the future.

Cheers!
