### PR TITLE
updated path_to_regexp to 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^4.3.4",
-    "path-to-regexp": "^6.2.2"
+    "path-to-regexp": "^6.3.0"
   },
   "devDependencies": {
     "@kapouer/eslint-config": "^2.0.0",


### PR DESCRIPTION
Need to update package.json file to fix vulnerable dependency in project express-urlwrite.